### PR TITLE
Removing out of place options for bxSlider

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
 			</section>
 		</div>
 		<script type="text/javascript">
+			// Only .slider1 is actually being used here. You could probably drop 2 and 3 to save some processing.
 			$('.slider1').bxSlider({
 				mode: 'fade',
 				captions: false,
@@ -65,10 +66,7 @@
 				pager:false,
 				controls:false,
 			});
-			Ext.Loader.setConfig({
-    disableCaching: false,
-    enabled: true
-});
+			// this bit was breaking it.
 		</script>
 <!--- Slider End -->
 	</div>


### PR DESCRIPTION
Looks like you had some out of place options for bxSlider. I left a comment in the code where these options use to be.

Also made a note about .slider2 and .slider3 in the form of another comment.

Let me know if you have any more questions!